### PR TITLE
Reorder PostgresChangesData so that UPDATE and DELETE changes dont fa…

### DIFF
--- a/src/message/payload.rs
+++ b/src/message/payload.rs
@@ -105,15 +105,15 @@ pub struct PostgresChangesPayload {
 /// Recieved data regarding a postgres change
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PostgresChangeData {
-    pub columns: Vec<PostgresColumn>,
-    pub commit_timestamp: String,
-    pub errors: Option<String>,
-    pub old_record: Option<PostgresOldDataRef>,
-    pub record: Option<HashMap<String, Value>>,
-    #[serde(rename = "type")]
-    pub change_type: PostgresChangesEvent,
-    pub schema: String,
     pub table: String,
+    #[serde(rename = "type")]
+    pub change_type: String,
+    pub record: Option<HashMap<String, Value>>,
+    pub columns: Vec<PostgresColumn>,
+    pub errors: Option<String>,
+    pub schema: String,
+    pub commit_timestamp: String,
+    pub old_record: Option<HashMap<String, Value>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -182,6 +182,18 @@ pub enum PostgresChangesEvent {
     Update,
     #[serde(rename = "DELETE")]
     Delete,
+}
+
+impl PostgresChangesEvent {
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "INSERT" => Some(PostgresChangesEvent::Insert),
+            "UPDATE" => Some(PostgresChangesEvent::Update),
+            "DELETE" => Some(PostgresChangesEvent::Delete),
+            "*" => Some(PostgresChangesEvent::All),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]

--- a/src/realtime_channel.rs
+++ b/src/realtime_channel.rs
@@ -363,7 +363,7 @@ impl RealtimeChannel {
                         }
                     }
                     Payload::PostgresChanges(ref payload) => {
-                        if let Some(cb_vec) = cdc_callbacks.get_mut(&payload.data.change_type) {
+                        if let Some(cb_vec) = cdc_callbacks.get_mut(&PostgresChangesEvent::from_str(&payload.data.change_type).unwrap()) {
                             for cb in cb_vec {
                                 if !cb.0.check(&message) {
                                     continue;


### PR DESCRIPTION
Hi, good job on the library.

I had issues with serde failing to parse PostgresChanges on UPDATE and DELETE. Worked fine on INSERT. The reason was because UPDATE and DELETE contained fields that were not in INSERT message. By reordering the data struct everything works great.